### PR TITLE
ES teleport fix and item dict additions

### DIFF
--- a/TrainerReborn/Dicts.cs
+++ b/TrainerReborn/Dicts.cs
@@ -246,6 +246,18 @@ namespace TrainerReborn
                 "29"
             },
             {
+                "SecondWind",
+                "37"
+            },
+            {
+                "CurrentsMaster",
+                "39"
+            },
+            {
+                "Currents",
+                "39"
+            },
+            {
                 "LigthfootTabi", // Keep the typo in for people who are used to it
                 "40"
             },
@@ -260,6 +272,18 @@ namespace TrainerReborn
             {
                 "MagicBoots",
                 "40"
+            },
+            {
+                "WingsuitSlash",
+                "41"
+            },
+            {
+                "Aerobatics",
+                "41"
+            },
+            {
+                "WSS",
+                "41"
             },
             {
                 "Scroll",
@@ -350,6 +374,18 @@ namespace TrainerReborn
                 "60"
             },
             {
+                "DemonsBane",
+                "63"
+            },
+            {
+                "StrikeoftheNinja",
+                "64"
+            },
+            {
+                "Strike",
+                "64"
+            },
+            {
                 "Jukebox",
                 "73"
             },
@@ -368,7 +404,7 @@ namespace TrainerReborn
             {
                 "MoneyWrench",
                 "77"
-            }
+            }               
         };
         }
 

--- a/TrainerReborn/Dicts.cs
+++ b/TrainerReborn/Dicts.cs
@@ -404,7 +404,7 @@ namespace TrainerReborn
             {
                 "MoneyWrench",
                 "77"
-            }               
+            }   
         };
         }
 


### PR DESCRIPTION
If you teleport to ES you won't start on Manfred anymore. If you want to do the beginning shmup section on Manfred you can travel to ES by talking to Manfred in GP.

Add useful upgrades to itemDict.